### PR TITLE
Added clarity for Linux users who may face troubleshooting issues

### DIFF
--- a/modules/03-github-version-control/lesson-github-vcs.md
+++ b/modules/03-github-version-control/lesson-github-vcs.md
@@ -65,6 +65,8 @@ If an error comes up, install gcm (git-credential-manager) and/or run
 git-credential-manager configure
 ```
 
+then try the above command(s) again.
+
 #### More linux options
 
 There are instructions for installing git on several different Unix distributions on the [Git website](https://git-scm.com/download/linux).

--- a/modules/03-github-version-control/lesson-github-vcs.md
+++ b/modules/03-github-version-control/lesson-github-vcs.md
@@ -53,6 +53,18 @@ sudo dnf install git-all
 sudo apt install git-all
 ```
 
+#### Additional troubleshooting instructions for enabling linux 2FA (needed for git to work), can occur with Linux Mint
+
+```bash
+git config --global credential.credentialStore secretservice
+```
+
+If an error comes up, install gcm (git-credential-manager) and/or run
+
+```bash
+git-credential-manager configure
+```
+
 #### More linux options
 
 There are instructions for installing git on several different Unix distributions on the [Git website](https://git-scm.com/download/linux).


### PR DESCRIPTION
When I tried to set up git properly with Linux mint I was unable to use 2 factor authentication to log into my account via the git credential manager. Just to be safe, I've added a few lines of code to troubleshoot this potential issue for linux users facing these kinds of problems in the future.